### PR TITLE
vertically align the task list item <label>

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ module.exports = function(content, opts) {
   render_item_checkbox = function(html, checked, disabled) {
     var label;
     label = html.slice(3, +(html.length - 1) + 1 || 9e9);
-    return "<label>\n  <input type=\"checkbox\"\n  class=\"task-list-item-checkbox\"\n  " + checked + "\n  " + disabled + "/>\n  " + label + "\n</label>";
+    return "<label style=\"vertical-align:top;\">\n  <input type=\"checkbox\"\n  class=\"task-list-item-checkbox\"\n  " + checked + "\n  " + disabled + "/>\n  " + label + "\n</label>";
   };
   list_iterator = function(item) {
     var detached, disabled, srcHtml;


### PR DESCRIPTION
Vertically align the task list item <label> so that the list item's bullet always appears to the left of the first line of the task when the task's text wraps.  This addresses an issue where the list item's bullet will appear to the left of the _last_ line of the task when the task's text wraps and <label style="display:inline-block;">, as discussed in gjtorikian/task-lists-js#5 and atom/markdown-preview#142